### PR TITLE
Reject query params with an equals sign but no value

### DIFF
--- a/urlauth/urlauth_test.go
+++ b/urlauth/urlauth_test.go
@@ -56,6 +56,22 @@ func TestSignURL(t *testing.T) {
 			want: "https://www.example.com/foo?bar=1&e=1544720086&st=b805320d706d8501124ad907a505fbeb",
 		},
 		{
+			name: "URL with multiple query params where one of the params has an equal sign and no value",
+			args: args{
+				url:    "https://www.example.com/foo?bar=&baz=ok",
+				secret: "supersecret", expirationTime: &expirationTime,
+			},
+			wantErr: true,
+		},
+		{
+			name: "URL with multiple query params where one of the params has an equal sign and no value",
+			args: args{
+				url:    "https://www.example.com/foo?bar=ok&baz=",
+				secret: "supersecret", expirationTime: &expirationTime,
+			},
+			wantErr: true,
+		},
+		{
 			name: "Valid URL without a query-param",
 			args: args{
 				url:            "https://www.example.com/foo",
@@ -102,5 +118,13 @@ func TestSignURL(t *testing.T) {
 				t.Errorf("SignURL() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func Benchmark_URLAuth_SignURL(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		if _, err := SignURL("https://www.example.com/foo?bar=1", "supersecret", &expirationTime); err != nil {
+			b.Logf("URLAuth.SignURL() error = %v", err)
+		}
 	}
 }


### PR DESCRIPTION
Highwinds rejects signed URLs containing a query parameter with an empty value, such as `http://www.example.com/foo?bar=` or `http://www.example.com/foo?bar=&baz=ok`.

However, it is okay to specify a query parameter without an equals sign, such as  `http://www.example.com/foo?bar` or `http://www.example.com/foo?bar&baz=ok`.

This PR introduces a validation step that rejects invalid query parameters.

Also included are some performance optimizations and a benchmark to demonstrate:

## Without string-formatting optimizations
```
goos: darwin
goarch: amd64
pkg: github.com/muxinc/highwinds-urlauth/urlauth
Benchmark_URLAuth_SignURL-12    	 1017592	      1184 ns/op	     680 B/op	      19 allocs/op
PASS
ok  	github.com/muxinc/highwinds-urlauth/urlauth	2.133s
Success: Benchmarks passed.
```

## With string-formatting optimizations
```
goos: darwin
goarch: amd64
pkg: github.com/muxinc/highwinds-urlauth/urlauth
Benchmark_URLAuth_SignURL-12    	 1340202	       919 ns/op	     584 B/op	      14 allocs/op
PASS
ok  	github.com/muxinc/highwinds-urlauth/urlauth	2.095s
Success: Benchmarks passed.
```